### PR TITLE
Add actions workflow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Charts Repo Actions Demo
 
+[![](https://github.com/helm/charts-repo-actions-demo/workflows/Lint%20and%20Test%20Charts/badge.svg)](https://github.com/helm/charts-repo-actions-demo/actions)
+[![](https://github.com/helm/charts-repo-actions-demo/workflows/Release%20Charts/badge.svg?branch=master)](https://github.com/helm/charts-repo-actions-demo/actions)
+
 Example project to demo testing and hosting a chart repository with GitHub Pages and Actions.
 
 ## Actions

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Charts Repo Actions Demo
 
-[![](https://github.com/helm/charts-repo-actions-demo/workflows/Lint%20and%20Test%20Charts/badge.svg)](https://github.com/helm/charts-repo-actions-demo/actions)
 [![](https://github.com/helm/charts-repo-actions-demo/workflows/Release%20Charts/badge.svg?branch=master)](https://github.com/helm/charts-repo-actions-demo/actions)
 
 Example project to demo testing and hosting a chart repository with GitHub Pages and Actions.


### PR DESCRIPTION
Maybe we don't want the `Lint and Test Charts` badge, since that's run on PRs, it may seem as if the repo is not stable when it's only PRs that are not passing. Anyway, adding for discussion.