### PR TITLE
Bump new chart versions to trigger releases

### DIFF
--- a/charts/dependencies-v1/Chart.yaml
+++ b/charts/dependencies-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: dependencies-v1
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.0
+version: 0.1.1

--- a/charts/dependencies-v2/Chart.yaml
+++ b/charts/dependencies-v2/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: dependencies-v2
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.0
+version: 0.1.1
 dependencies:
   - name: redis
     version: 10.5.13

--- a/charts/example-v1/Chart.yaml
+++ b/charts/example-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v1
 sources:
   - https://github.com/helm/helm
-version: 0.1.3
+version: 0.1.4

--- a/charts/example-v2/Chart.yaml
+++ b/charts/example-v2/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v2
 sources:
   - https://github.com/helm/helm
-version: 0.2.0
+version: 0.2.1


### PR DESCRIPTION
Note this is due to a mismatch of configuration and version of [@helm/chart-releaser-action](https://github.com/helm/chart-releaser-action) in #10, where the new test charts were introduced. The issue was fixed in #12, but they won't now be seen as new without a version bump.

Alternatively, we could fix this in one of several other ways:
- Revert the PR that introduced the new charts, merge to master, then re-revert in a new PR (I personally don't think that's better than a version bump at this point - these are test charts after all)
- Fix merge conflicts in this PR https://github.com/helm/chart-releaser/pull/45, merge it, and run chart-releaser to manually add releases for the existing versions (I prefer the version bump - we could still use this to back-fill the missing versions if we wanted to)

I'm mentioning these alternatives mainly for the sake of others who may run across this issue due to a similar misconfiguration in their own chart repos causing helm/chart-releaser-action to skip a version of their chart(s).