### PR TITLE
Test chart-releaser-action on master prior to releasing chart-releaser-action@v1.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,6 @@ jobs:
           helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-rc.2
+        uses: helm/chart-releaser-action@master
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/charts/dependencies-v1/Chart.yaml
+++ b/charts/dependencies-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: dependencies-v1
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.3
+version: 0.1.4

--- a/charts/dependencies-v2/Chart.yaml
+++ b/charts/dependencies-v2/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: dependencies-v2
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.3
+version: 0.1.4
 dependencies:
   - name: redis
     version: 10.5.13

--- a/charts/example-v1/Chart.yaml
+++ b/charts/example-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v1
 sources:
   - https://github.com/helm/helm
-version: 0.1.6
+version: 0.1.7

--- a/charts/example-v2/Chart.yaml
+++ b/charts/example-v2/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v2
 sources:
   - https://github.com/helm/helm
-version: 0.2.3
+version: 0.2.4


### PR DESCRIPTION
~⚠️ don't merge yet~

To test chart-releaser action before v1.0.0 is released, we can merge this PR pointing to `chart-releser-action@master`. There will be a fast-follow PR to bump to `chart-releaser-action@v1.0.0`