### PR TITLE
Bump to helm/chart-releaser-action@v1.0.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,6 @@ jobs:
           helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@master
+        uses: helm/chart-releaser-action@v1.0.0
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"


### PR DESCRIPTION
Fast follow from #22 

Now that https://github.com/helm/chart-releaser-action/releases/tag/v1.0.0 is available

Signed-off-by: Scott Rigby <scott@r6by.com>