### PR TITLE
Use GITHUB_TOKEN

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,4 +35,4 @@ jobs:
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0
         env:
-          CR_TOKEN: "${{ secrets.CR_TOKEN }}"
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -25,24 +25,14 @@ Example project to demo testing and hosting a chart repository with GitHub Pages
 
 You can automatically test and host your own chart repository with GitHub Pages and Actions by following these steps.
 
-### Prerequisites
-
-* A GitHub project to use for your Charts repo (a clean project is most straightforward, as there won't be release cluttering or possible `gh-pages` conflicts)
-* A branch to use for GitHub Pages (`gh-pages` is most straightforward, as it's the default and requires no configuration)
-* A project [Secret](https://help.github.com/en/actions/automating-your-workflow-with-github-actions/creating-and-using-encrypted-secrets#creating-encrypted-secrets) named `CR_TOKEN` with the value of a GitHub [personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line#creating-a-token)
-  * The token must have `repo` scope
-  * The token's user must have write access to the project
-  * To mitigate risk you may wish to limit the token to a single project by creating a [machine user](https://developer.github.com/v3/guides/managing-deploy-keys/#machine-users)
-  * Please note the personal access token is required because of an [Actions bug](https://github.community/t5/GitHub-Actions/Github-action-not-triggering-gh-pages-upon-push/m-p/31266/highlight/true#M743), and will hopefully be unnecessary in the future
-
 ### Steps
 
-The above [prerequisites](#prerequisites) _must_ be complete before the steps below, or your charts' initial versions won't be released.
+The prerequisites listed in the READMEs for [actions](#actions) above _must_ be complete before the steps below, or your charts' initial versions won't be released.
 
 1. Use the `master` branch for all of the below, if you wish to use the Actions workflow files as-is
 1. Copy the `.github/workflows` files from this project to yours
 1. Add your charts to a parent directory in the project (`/charts` is most straightforward, as it's the default. To change this see [helm/chart-testing > configuration > chart-dirs](https://github.com/helm/chart-testing#configuration))
-1. Optional: To list your charts repo publicly on the [Helm Hub](https://hub.helm.sh), see [Helm Hub > How To Add Your Helm Charts](https://github.com/helm/hub#how-to-add-your-helm-charts)
+1. Optional: To list your charts repo publicly on the [Helm Hub](https://hub.helm.sh), see [Helm Hub > How To Add Your Helm Charts](https://github.com/helm/hub#how-to-add-your-helm-charts). Consider also pushing to [CNCF Artifact Hub](https://artifacthub.io/)
 
 ### Results
 

--- a/charts/dependencies-v1/Chart.yaml
+++ b/charts/dependencies-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: dependencies-v1
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.4
+version: 0.1.5

--- a/charts/dependencies-v2/Chart.yaml
+++ b/charts/dependencies-v2/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: dependencies-v2
 sources:
   - https://github.com/helm/charts-repo-actions-demo
-version: 0.1.4
+version: 0.1.5
 dependencies:
   - name: redis
     version: 10.5.13

--- a/charts/example-v1/Chart.yaml
+++ b/charts/example-v1/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v1
 sources:
   - https://github.com/helm/helm
-version: 0.1.7
+version: 0.1.8

--- a/charts/example-v2/Chart.yaml
+++ b/charts/example-v2/Chart.yaml
@@ -8,4 +8,4 @@ maintainers:
 name: example-v2
 sources:
   - https://github.com/helm/helm
-version: 0.2.4
+version: 0.2.5


### PR DESCRIPTION
Forgot to do this in https://github.com/helm/charts-repo-actions-demo/pull/23

See https://github.com/helm/chart-releaser-action/pull/26

Also take this opportunity to simplify redundancy in README. Just link to prerequisites in the other action READMEs in case of future changes.

Signed-off-by: Scott Rigby <scott@r6by.com>