### PR TITLE
Update stable and incubator repo URLs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add incubator https://charts.helm.sh/incubator
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0


### PR DESCRIPTION
See https://helm.sh/blog/new-location-stable-incubator-charts/

We may clear these out anyway, since there are no dependencies from these repos. But updating for now for others emulating this demo setup. Later we can revisit which dependencies we want to demo.